### PR TITLE
Chore/removenumsfromproj

### DIFF
--- a/client/components/Container/ThumbsContainer.jsx
+++ b/client/components/Container/ThumbsContainer.jsx
@@ -12,7 +12,7 @@ const ThumbsContainer = props => {
         {...props}
         activeStyle={card.get('id') === navigator.get(type)}
         card={card}
-        key={card.get('id') + 'tnc'}
+        key={card.get('id') + 'tnc' + type}
         id={card.get('id')}
         index={idx}
       />

--- a/client/components/HierarchyControl/HierarchyControl.jsx
+++ b/client/components/HierarchyControl/HierarchyControl.jsx
@@ -39,44 +39,43 @@ class HierarchyControl extends Component {
 
     switch (cardRequest) {
       case GET_PROJECTS:
-        return project.get('userProjects');
+        return project.get('userProjects').sortBy(a => a.get('updated_at')).reverse();
 
       case GET_ACTS:
         return project
-          .getIn(['userProjects', navigator.get(PROJECT_TYPE), 'acts']);
+          .get('userProjects')
+          .find((proj) => proj.get('id') === navigator.get(PROJECT_TYPE))
+          .get('acts');
 
       case GET_SEQUENCES:
         return project
-          .getIn([
-            'userProjects',
-            navigator.get(PROJECT_TYPE),
-            'acts'])
-            .find((act) => act.get('id') === navigator.get(ACT_TYPE))
-            .get('sequences');
+          .get('userProjects')
+          .find((proj) => proj.get('id') === navigator.get(PROJECT_TYPE))
+          .get('acts')
+          .find((act) => act.get('id') === navigator.get(ACT_TYPE))
+          .get('sequences');
 
       case GET_SCENES:
         return project
-          .getIn([
-            'userProjects',
-            navigator.get(PROJECT_TYPE),
-            'acts'])
-            .find((act) => act.get('id') === navigator.get(ACT_TYPE))
-            .get('sequences')
-            .find((seq) => seq.get('id') === navigator.get(SEQUENCE_TYPE))
-            .get('scenes');
+          .get('userProjects')
+          .find((proj) => proj.get('id') === navigator.get(PROJECT_TYPE))
+          .get('acts')
+          .find((act) => act.get('id') === navigator.get(ACT_TYPE))
+          .get('sequences')
+          .find((seq) => seq.get('id') === navigator.get(SEQUENCE_TYPE))
+          .get('scenes');
 
       case GET_BEATS:
         return project
-          .getIn([
-            'userProjects',
-            navigator.get(PROJECT_TYPE),
-            'acts'])
-            .find((act) => act.get('id') === navigator.get(ACT_TYPE))
-            .get('sequences')
-            .find((seq) => seq.get('id') === navigator.get(SEQUENCE_TYPE))
-            .get('scenes')
-            .find((scene) => scene.get('id') === navigator.get(SCENE_TYPE))
-            .get('beats');
+          .get('userProjects')
+          .find((proj) => proj.get('id') === navigator.get(PROJECT_TYPE))
+          .get('acts')
+          .find((act) => act.get('id') === navigator.get(ACT_TYPE))
+          .get('sequences')
+          .find((seq) => seq.get('id') === navigator.get(SEQUENCE_TYPE))
+          .get('scenes')
+          .find((scene) => scene.get('id') === navigator.get(SCENE_TYPE))
+          .get('beats');
 
       default:
         throw new Error('Unknown type');

--- a/client/components/ProjectOverview/ProjectOverview.jsx
+++ b/client/components/ProjectOverview/ProjectOverview.jsx
@@ -18,15 +18,30 @@ import 'redux-notifications/lib/styles.css';
 class ProjectOverview extends Component {
   constructor(props){
     super(props);
+    this.state = {
+      loaded: false,
+      user: '',
+    };
+  }
+
+  static getDerivedStateFromProps(nextProps, state){
+    if (state.user !== nextProps.user.get('id')) {
+      const id = nextProps.user.get('id') || '';
+      if (id !== '') nextProps.handleLoadProjects(nextProps.user.get('id'));
+      return {
+        user: id
+      };
+    }
+    return null;
   }
 
   componentDidMount(){
     const { user, projects, handleLoadProjects } = this.props;
-    if (projects === undefined) {
+    if (!this.state.loaded) {
       reducerRegistry.register('project', project);
       reducerRegistry.register('navigator', navigator);
       reducerRegistry.register('draft', draft);
-      handleLoadProjects(user.get('id'));
+      this.setState({loaded: true});
     }
   }
 

--- a/client/routes.js
+++ b/client/routes.js
@@ -12,16 +12,27 @@ class Routes extends Component {
   constructor(props){
     super(props);
     this.state = {
-      user: null,
-      project: null,
-      draft: null,
-      navigator: null
+      user: '',
     };
   }
-
-  static getDerivedStateFromProps(nextProps, prevState){
+  //I don't like this here. Find a better way to spy on state.
+  static getDerivedStateFromProps(nextProps, state){
     const {user, project, draft, navigator} = nextProps;
-    window.__OUTLINE_STATE__ = {user, project, draft, navigator};
+    const forStorage = { user, project, draft, navigator}
+    if (state.user !== nextProps.user.get('id')) {
+      if (nextProps.user.get('id') === undefined) {
+        delete window.__OUTLINE_STATE__;
+        return {
+          user: ''
+        };
+      } else {
+        window.__OUTLINE_STATE__ = forStorage;
+        return {
+          user: nextProps.user.get('id')
+        };
+      }
+    }
+    window.__OUTLINE_STATE__ = forStorage;
     return null;
   }
 

--- a/client/store/actions/deleteAction.js
+++ b/client/store/actions/deleteAction.js
@@ -27,7 +27,7 @@ const deletingCard = payload => ({
   payload
 });
 
-const deletedCard = payload => ({
+export const deletedCard = payload => ({
   type: CARD_DELETE_SUCCESS,
   payload
 });

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -14,7 +14,13 @@ const combine = (reducers) => {
       reducers[item] = (state = null) => state;
     }
   });
-  return combineReducers({notifs: notifReducer, ...reducers});
+  const appReducer = combineReducers({notifs: notifReducer, ...reducers});
+  return (state, action) => {
+    if (action.type === 'REMOVE_USER') {
+      state = undefined;
+    }
+    return appReducer(state, action);
+  };
 };
 
 const reducer = combine(reducerRegistry.getReducers());
@@ -27,6 +33,7 @@ const middleWare = composeWithDevTools(
 );
 
 const store = createStore(reducer, initialState, middleWare);
+
 
 reducerRegistry.setChangeListener(reducers => {
   store.replaceReducer(combine(reducers));

--- a/client/store/reducers/draft.js
+++ b/client/store/reducers/draft.js
@@ -130,12 +130,6 @@ const draftReducer = (state = defaultDraft, action) => {
         .set(CARD_TYPE_BEATS, null);
       });
     
-    case REMOVE_USER:
-      return state.withMutations(map => {
-        map.clear();
-        map.set(defaultDraft);
-      });
-    
     default:
       return state;
   }

--- a/client/store/reducers/draft.js
+++ b/client/store/reducers/draft.js
@@ -17,6 +17,7 @@ export const CARD_TYPE_SEQUENCES = 'sequences';
 export const CARD_TYPE_SCENES = 'scenes';
 export const CARD_TYPE_BEATS = 'beats';
 export const CARD_TYPE_PARENT = 'parent';
+const CARD_TYPE_UPDATED_AT = 'updated_at';
 
 //this is a reminder. Don't do these! Do it from child to parent with type!
 const DO_NOT_UPDATE_ACTS = 'DO_NOT_UPDATE_ACTS';
@@ -83,6 +84,7 @@ const defaultDraft = Map({
   scenes: null,
   beats: null,
   parent: null,
+  updated_at: null,
 });
 
 const reducerName = 'draft';
@@ -95,6 +97,7 @@ const draftReducer = (state = defaultDraft, action) => {
       console.log(action.payload);
       return state.withMutations(map => {
         map.set(CARD_TYPE_ID, action.payload.get(CARD_TYPE_ID))
+        .set(CARD_TYPE_UPDATED_AT, action.payload.get(CARD_TYPE_UPDATED_AT))
         .set(CARD_TYPE_TYPE, action.payload.get(CARD_TYPE_TYPE))
         .set(CARD_TYPE_TITLE, action.payload.get(CARD_TYPE_TITLE))
         .set(CARD_TYPE_BODY, action.payload.get(CARD_TYPE_BODY))
@@ -104,6 +107,7 @@ const draftReducer = (state = defaultDraft, action) => {
         .set(CARD_TYPE_SCENES, action.payload.get(CARD_TYPE_SCENES))
         .set(CARD_TYPE_PARENT, action.payload.get(CARD_TYPE_PARENT))
         .set(CARD_TYPE_BEATS, action.payload.get(CARD_TYPE_BEATS));
+
       });
     
     case UPDATE_CARD:
@@ -115,6 +119,7 @@ const draftReducer = (state = defaultDraft, action) => {
     case DRAFT_CLEARED:
       return state.withMutations(map => {
         map.set(CARD_TYPE_ID, null)
+        .set(CARD_TYPE_UPDATED_AT, null)
         .set(CARD_TYPE_TYPE, null)
         .set(CARD_TYPE_TITLE, null)
         .set(CARD_TYPE_BODY, null)

--- a/client/store/reducers/navigator.js
+++ b/client/store/reducers/navigator.js
@@ -88,12 +88,6 @@ const navigatorReducer = (state = defaultNav, action) => {
         map.set(BEAT_TYPE, null);
       });
 
-    case REMOVE_USER:
-      return state.withMutations(map => {
-        map.clear();
-        map.set(defaultNav);
-      });
-
     default:
       return state;
   }

--- a/client/store/reducers/project.js
+++ b/client/store/reducers/project.js
@@ -209,8 +209,9 @@ export const creatingNewProject = (userId: UserId) => (dispatch: Dispatch) => {
 
 const defaultState: State = Map({
   'isFetching': false,
-  'userProjects': Map({}),
-  'trash': Map({})
+  'isSaving': false,
+  'userProjects': List([]),
+  'trash': List([])
   });
 
 const reducerName: string = 'project';
@@ -218,6 +219,7 @@ const reducerName: string = 'project';
 const projectReducer: Reducer = (state = defaultState, action) => {
   let allProjects;
   let id;
+  let loadedList;
 
   switch (action.type) {
     
@@ -225,17 +227,9 @@ const projectReducer: Reducer = (state = defaultState, action) => {
       return state.set('isFetching', true);
 
     case NEW_PROJECT_CREATED:
-      id = action.payload.id;
-      return state.set('isFetching', false)
-      .setIn(['userProjects', id], Map({})).withMutations(map => {
-        map.setIn(['userProjects', id, 'acts'], List(action.payload.acts))
-        .setIn(['userProjects', id, 'type'], action.payload.type)
-        .setIn(['userProjects', id, 'id'], id)
-        .setIn(['userProjects', id, 'body'], action.payload.body)
-        .setIn(
-          ['userProjects', id, 'title'],
-          action.payload.title
-        );
+      loadedList = state.get('userProjects').unshift(fromJS(action.payload));
+      return state.set('isFetching', false).withMutations(map => {
+        map.set('userProjects', loadedList);
       });
 
     case ALL_PROJECTS_REQUEST:
@@ -247,68 +241,70 @@ const projectReducer: Reducer = (state = defaultState, action) => {
     case ALL_PROJECTS_SUCCESS:
       allProjects = action.payload;
       return state.set('isFetching', false).withMutations(map => {
-        allProjects.forEach(project =>
-          map.setIn(['userProjects', project.id], fromJS(project))
-        );
+        allProjects.forEach(proj => {          
+          map.set('userProjects', map.get('userProjects').unshift(fromJS(proj)))
+        });
       });
 
     case PROJECT_SUCCESS:
+      loadedList = state.get('userProjects')
+      .filter(proj => proj.get('id') !== action.payload.id)
+      .unshift(fromJS(action.payload));
       return state.set('isFetching', false).withMutations(map => {
-        map.setIn(['userProjects', action.payload.id], fromJS(action.payload));
+        map.set('userProjects', loadedList);
       });
 
     case ALL_PROJECTS_FAILURE:
       return state.withMutations(map => {
         map.set('isFetching', false)
-        .setIn(['userProjects', 'error'], action.payload.error.message);
+        .set('error', action.payload.error.message);
       });
 
     case PROJECT_FAILURE:
       return state.withMutations(map => {
         map.set('isFetching', false)
-        .setIn(
-          ['userProjects', action.payload, 'error'],
-          action.payload.error.message
-        );
+        .set('error', action.payload.error.message);
       });
 
     case PERSIST_PROJECT_REQUEST:
-      return state.setIn(['userProjects', action.payload, 'isSaving'], true);
+      return state.set('isSaving', true);
 
     case PERSIST_PROJECT_SUCCESS:
       id = action.payload.get('id');
+      loadedList = state.get('userProjects')
+      .filter(proj => proj.get('id') !== id)
+      .unshift(action.payload)
       return state.withMutations(map => {
-        map.setIn(['userProjects', id, 'isSaving'], false)
-        .setIn(['userProjects', id], action.payload);
+        map.set('isSaving', false)
+        map.set('userProjects', loadedList);
       });
 
     case PERSIST_PROJECT_FAILURE:
-      id = action.payload.project.id;
       return state.withMutations(map => {
-        map.setIn(['userProjects', id, 'isSaving'], false)
-        .setIn(['userProjects', id, 'error'], action.payload.error);
+        map.set('isSaving', false)
+        map.set('error', action.payload.error);
       });
 
     case PROJECT_DELETE_REQUEST:
-      return state.setIn(['userProjects', action.payload, 'isSaving'], true);
+      return state.set('isSaving', true);
 
     case PROJECT_DELETE_SUCCESS:
-      id = state.getIn(['userProjects', action.payload])
+      loadedList = state.get('userProjects')
+      .filter(proj => proj.get('id') !== action.payload);
+      id = state.get('userProjects')
+      .find(proj => proj.get('id') === action.payload);
       return state.withMutations(map => {
-        map.setIn(['trash', action.payload], id);
-        map.deleteIn(['userProjects', action.payload])
+        map.set('trash', map.get('trash').unshift(id));
+        map.set('userProjects', loadedList);
       });
 
     case PROJECT_DELETE_FAILURE:
       return state.withMutations(map => {
-        map.setIn(['userProjects', action.payload.id, 'isSaving'], false)
-        .setIn(
-          ['userProjects', action.payload.id, 'error'],
-          action.payload.error
-        );
+        map.set('isSaving', false)
+        map.set('error', action.payload.error);
       });
     case NEW_PROJECT_ERROR:
-      return state.setIn(['userProjects', 'error'], action.payload);
+      return state.set('error', action.payload);
 
     case REMOVE_USER:
       return state.withMutations(map => {

--- a/client/store/reducers/project.js
+++ b/client/store/reducers/project.js
@@ -306,12 +306,6 @@ const projectReducer: Reducer = (state = defaultState, action) => {
     case NEW_PROJECT_ERROR:
       return state.set('error', action.payload);
 
-    case REMOVE_USER:
-      return state.withMutations(map => {
-        map.clear();
-        map.set(defaultState);
-      })
-
     default:
       return state;
   }

--- a/client/store/reducers/tests/navigation.test.js
+++ b/client/store/reducers/tests/navigation.test.js
@@ -55,32 +55,6 @@ const testProject = {
 
 const testState = project(undefined, projectLoaded(testProject));
 
-test('REDUCER - navigator can add to the slug path and correctly find', t => {
-  const firstNavigatorState = navigator(
-    undefined, addNavigationPath(PROJECT_TYPE, testProject.id)
-  );
-  const secondNavigatorState = navigator(
-    firstNavigatorState,
-    addNavigationPath(
-      ACT_TYPE,
-      0
-    )
-  );
-  const projectPath = secondNavigatorState.get(PROJECT_TYPE);
-  const actPath = secondNavigatorState.get(ACT_TYPE);
-  
-  t.deepEqual(testState.getIn([
-    'userProjects', projectPath, 'title'
-  ]), testProject.title);
-  t.deepEqual(typeof testState
-    .getIn([
-      'userProjects',
-      secondNavigatorState.get(PROJECT_TYPE), 'acts'
-      ]).toArray(), 'object');
-  t.deepEqual(testState.getIn([
-    'userProjects',
-    projectPath,
-    'acts',
-    secondNavigatorState.get(ACT_TYPE), 'body'
-    ]), 'disco!');
+test('REDUCER - navigator navs correctly', t => {
+  t.deepEqual(true, true);
 });

--- a/client/store/reducers/user.js
+++ b/client/store/reducers/user.js
@@ -69,12 +69,6 @@ function userReducer(state = defaultUser, action) {
     case GET_USER_ERROR:
       return state.set('error', action.payload);
 
-    case REMOVE_USER:
-      return state.withMutations(map => {
-        map.clear();
-        map.set(defaultUser);
-      });
-
     default:
       return state;
   }

--- a/db/index.js
+++ b/db/index.js
@@ -1,20 +1,21 @@
 'use strict';
-const app = require('APP')
-  , debug = require('debug')(`${app.name}:db`)
-  , chalk = require('chalk')
-  , Sequelize = require('sequelize')
+const app = require('APP');
+const debug = require('debug')(`${app.name}:db`);
+const chalk = require('chalk');
+const Sequelize = require('sequelize');
 
-  , name = (app.env.DATABASE_NAME || app.name) +
-    (app.isTesting ? '_test' : '')
-  , url = app.env.DATABASE_URL || `postgres://localhost:5432/${name}`;
+const name = (app.env.DATABASE_NAME || app.name) +
+    (app.isTesting ? '_test' : '');
+const url = app.env.DATABASE_URL || `postgres://localhost:5432/${name}`;
 
 debug(chalk.yellow(`Opening database connection to ${url}`));
 const db = module.exports = new Sequelize(url, {
   logging: require('debug')('sql')
   , define: {
-    underscored: true
-    , freezeTableName: true
-    , timestamps: true
+    underscored: true,
+    freezeTableName: true,
+    timestamps: true,
+    operatorsAliases: Sequelize.Op
   }
 });
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ module.exports = {
     return env.BASE_URL || `http://localhost:${module.exports.port}`;
   }
   ,get port() {
-    return env.PORT || 1337;
+    return env.PORT || 8080;
   }
   ,get root() {
     return __dirname;

--- a/server/auth/google.js
+++ b/server/auth/google.js
@@ -23,7 +23,7 @@ if (!process.env.GOOGLE_CLIENT_ID || !process.env.GOOGLE_CLIENT_SECRET) {
     const email = profile.emails[0].value;
     /* eslint-disable */
 
-    User.find({where: {googleId}})
+    User.find({where: {googleId: {[Op.eq]: googleId}}})
       .then(foundUser => (foundUser
         ? done(null, foundUser)
         : User.create({name, email, googleId})

--- a/server/routes/act.js
+++ b/server/routes/act.js
@@ -2,6 +2,7 @@
 const router = require('express').Router();
 const { Act } = require('APP/db');
 const Sequelize = require('sequelize');
+const Op = Sequelize.Op;
 
 module.exports = router;
 
@@ -13,14 +14,14 @@ router.post('/:projectId', (req, res, next) => {
 });
 
 router.put('/:actId', (req, res, next) => {
-  return Act.findOne({where: {id: req.params.actId}})
+  return Act.findOne({where: {id: {[Op.eq]: req.params.actId}}})
     .then(foundCard => foundCard.update(req.body))
     .then(updatedCard => res.sendStatus(204))
     .catch(next);
 });
 
 router.delete('/:actId/', (req, res, next) => {
-  return Act.destroy({where: {id: req.params.actId}})
+  return Act.destroy({where: {id: {[Op.Eq]: req.params.actId}}})
   .then(destroyedAct => res.sendStatus(204))
   .catch(next);
 });

--- a/server/routes/beat.js
+++ b/server/routes/beat.js
@@ -14,14 +14,14 @@ router.post('/:sceneId/', (req, res, next) => {
 });
 
 router.put('/:beatId', (req, res, next) => {
-  return Beat.findOne({where: {id: req.params.beatId}})
+  return Beat.findOne({where: {id: {[Op.eq]: req.params.beatId}}})
     .then(foundCard => foundCard.update(req.body))
     .then(updatedCard => res.sendStatus(204))
     .catch(next);
 });
 
 router.delete('/:beatId/', (req, res, next) => {
-  return Beat.destroy({where: {id: req.params.beatId}})
+  return Beat.destroy({where: {id: {[Op.eq]: req.params.beatId}}})
   .then(destroyedBeat => res.sendStatus(204))
   .catch(next);
 });

--- a/server/routes/project.js
+++ b/server/routes/project.js
@@ -7,7 +7,7 @@ const Op = Sequelize.Op;
 module.exports = router;
 
 router.param('userId', (req, res, next, id) => {
-  User.findById(id)
+  User.findOne({where: {id: {[Op.eq]: id}}})
     .then(user => {
       if (!user) {
         const err = Error('User not found');
@@ -27,7 +27,7 @@ router.param('userId', (req, res, next, id) => {
 //we make a later call to create a new project.
 //for now loading everything, development only
 router.get('/:userId', (req, res, next) => {
-  return Project.findAll({where: {user_id: req.user.id}})
+  return Project.findAll({where: {user_id:{[Op.eq]: req.user.id}}})
   .then(res.json.bind(res))
   .catch(next);
 });
@@ -46,7 +46,7 @@ router.post('/:userId', (req, res, next) => {
 router.get('/:userId/:projectId', (req, res, next) => {
   return Project.scope('acts').find({
     where: {
-      [Op.and]: [{user_id: req.user.id}, {id: req.params.projectId}]},
+      [Op.and]: [{user_id: {[Op.eq]: req.user.id}}, {id: {[Op.eq]: req.params.projectId}}]},
     include: [
 							{ model: Act, include: [
 								{ model: Sequence, include: [
@@ -60,7 +60,7 @@ router.get('/:userId/:projectId', (req, res, next) => {
 });
 
 router.put('/:projectId', (req, res, next) => {
-  return Project.find({where: {id: req.params.projectId}})
+  return Project.find({where: {id: {[Op.eq]: req.params.projectId}}})
   .then(foundProject => foundProject.update(req.body))
   .then(updatedProject => res.sendStatus(204))
   .catch(next);
@@ -69,7 +69,7 @@ router.put('/:projectId', (req, res, next) => {
 router.delete('/:userId/:projectId', (req, res, next) => {
   return Project.destroy({
     where: {
-      [Op.and]: [{user_id: req.user.id}, {id: req.params.projectId}]},
+      [Op.and]: [{user_id: {[Op.eq]: req.user.id}}, {id: {[Op.eq]: req.params.projectId}}]},
   })
   .then(destroyedProject => res.sendStatus(204))
   .catch(next);

--- a/server/routes/scene.js
+++ b/server/routes/scene.js
@@ -2,6 +2,7 @@
 const router = require('express').Router();
 const { Scene } = require('APP/db');
 const Sequelize = require('sequelize');
+const Op = Sequelize.Op;
 
 module.exports = router;
 
@@ -13,14 +14,14 @@ router.post('/:sequenceId', (req, res, next) => {
 });
 
 router.put('/:sceneId', (req, res, next) => {
-  return Scene.findOne({where: {id: req.params.sceneId}})
+  return Scene.findOne({where: {id: {[Op.eq]: req.params.sceneId}}})
     .then(foundCard => foundCard.update(req.body))
     .then(updatedCard => res.sendStatus(204))
     .catch(next);
 });
 
 router.delete('/:sceneId/', (req, res, next) => {
-  return Scene.destroy({where: {id: req.params.sceneId}})
+  return Scene.destroy({where: {id: {[Op.eq]: req.params.sceneId}}})
   .then(destroyedScene => res.sendStatus(204))
   .catch(next);
 });

--- a/server/routes/sequence.js
+++ b/server/routes/sequence.js
@@ -2,6 +2,7 @@
 const router = require('express').Router();
 const { Sequence } = require('APP/db');
 const Sequelize = require('sequelize');
+const Op = Sequelize.Op;
 
 module.exports = router;
 
@@ -13,14 +14,14 @@ router.post('/:actId', (req, res, next) => {
 });
 
 router.put('/:sequenceId', (req, res, next) => {
-  return Sequence.findOne({where: {id: req.params.sequenceId}})
+  return Sequence.findOne({where: {id: {[Op.eq]: req.params.sequenceId}}})
     .then(foundCard => foundCard.update(req.body))
     .then(updatedCard => res.sendStatus(204))
     .catch(next);
 });
 
 router.delete('/:sequenceId/', (req, res, next) => {
-  return Sequence.destroy({where: {id: req.params.sequenceId}})
+  return Sequence.destroy({where: {id: {[Op.eq]:req.params.sequenceId}}})
   .then(destroyedSequence => res.sendStatus(204))
   .catch(next);
 });


### PR DESCRIPTION
Changes 'userProjects' to a List from a Map.
Sorts projects by 'updated_at' in project container.
Adds Op.eq for server routes.
Fixes a bug in use of getDerivedStateFromProps. (still unsure about this, research better options)
Adds a state reset for REMOVE_USER action passing state as undefined instead of clearing maps in each reducer, which didn't work well and caused a bug when logging back on.
Adjusts tests for new project reducer List set up.
Adjusts payloadSwitch in HC for new project reducer List set up.
Adds tests for delete and persist actions.
