### PR TITLE
removes mapStates where state is passed in props

### DIFF
--- a/client/components/HOC/LoaderHOC.js
+++ b/client/components/HOC/LoaderHOC.js
@@ -22,6 +22,7 @@ const LoaderHOC = (propName) => (WrappedComponent) => {
 
     render() {
       const EmptyReturn = this.props.empty ? this.props.empty : DefaultEmpty;
+      
       return checkIsEmpty(this.props[propName]) ?
       <EmptyReturn /> :
       <WrappedComponent {...this.props} />;

--- a/client/components/HierarchyControl/NavigationView.js
+++ b/client/components/HierarchyControl/NavigationView.js
@@ -17,14 +17,7 @@ const mapDispatch = dispatch => ({
   },
 });
 
-const mapState = state => ({
-  user: state.user,
-  project: state.project,
-  navigator: state.navigator,
-  draft: state.draft
-});
-
 const WrappedNavView = LoaderHOC('project')(NavigationView);
-const ConnectedNavView = connect(mapState, mapDispatch)(WrappedNavView);
+const ConnectedNavView = connect(null, mapDispatch)(WrappedNavView);
 
 export default ConnectedNavView;

--- a/client/components/HierarchyControl/NavigationViewLoader.js
+++ b/client/components/HierarchyControl/NavigationViewLoader.js
@@ -11,7 +11,10 @@ const LoadableComponent = Loadable({
 })
 
 export default class LoadableNavView extends Component {
+  constructor(props){
+    super(props);
+  }
   render() {
-    return <LoadableComponent />;
+    return <LoadableComponent {...this.props} />;
   }
 }

--- a/client/components/HierarchyControl/ReorderView.js
+++ b/client/components/HierarchyControl/ReorderView.js
@@ -21,14 +21,7 @@ const mapDispatch = dispatch => ({
     }
 });
 
-const mapState = state => ({
-  user: state.user,
-  project: state.project,
-  navigator: state.navigator,
-  order: state.order
-});
-
 const WrappedReorderView = LoaderHOC('project')(ReorderView);
-const ConnectedReorderView = connect(mapState, mapDispatch)(WrappedReorderView);
+const ConnectedReorderView = connect(null, mapDispatch)(WrappedReorderView);
 
 export default ConnectedReorderView;

--- a/client/components/HierarchyControl/ReorderViewLoader.js
+++ b/client/components/HierarchyControl/ReorderViewLoader.js
@@ -11,7 +11,10 @@ const LoadableComponent = Loadable({
 })
 
 export default class LoadableReorderView extends Component {
+  constructor(props){
+    super(props);
+  }
   render() {
-    return <LoadableComponent />;
+    return <LoadableComponent {...this.props} />;
   }
 }

--- a/client/components/ProjectOverview/ProjectOverview.js
+++ b/client/components/ProjectOverview/ProjectOverview.js
@@ -83,10 +83,10 @@ class ProjectOverview extends Component {
         </div>
         <Notifs />
         <Switch>
-           <Route exact path={`${match.url}/reorder`} render={() => <ReorderView />}/>
+           <Route exact path={`${match.url}/reorder`} render={() => <ReorderView {...this.props} />}/>
            <Route exact path={`${match.url}/fullview`} render={() => <FullView {...this.props} />}/>
            <Route exact path={`${match.url}/edit`} render={() => <CardEditor {...this.props} />}/>
-           <Route exact path={`${match.url}`} render={() => <NavigationView />}/>
+           <Route exact path={`${match.url}`} render={() => <NavigationView {...this.props} />}/>
         </Switch>
       </div>
 
@@ -98,7 +98,8 @@ const mapState = state => ({
   user: state.user,
   project: state.project,
   navigator: state.navigator,
-  draft: state.draft
+  draft: state.draft,
+  order: state.order
 });
 
 const mapDispatch = dispatch => ({

--- a/client/components/Reorder/ReorderContainer.js
+++ b/client/components/Reorder/ReorderContainer.js
@@ -99,10 +99,6 @@ class Container extends Component {
 	}
 }
 
-const mapState = state => ({
-	order: state.order
-});
-
 const mapDispatch = dispatch => ({
 	handleOrder(updateObj){
 		dispatch(updateOrder(updateObj))
@@ -114,4 +110,4 @@ const mapDispatch = dispatch => ({
 
 const ContainerTarget = DropTarget((props) => {return props.type}, cardTarget, collect)(Container);
 const ContainerContext = DragDropContext(HTML5Backend)(ContainerTarget);
-export default connect(mapState, mapDispatch)(LoaderHOC('thumbs')(ContainerContext));
+export default connect(null, mapDispatch)(LoaderHOC('thumbs')(ContainerContext));


### PR DESCRIPTION
Passes state from ProjectOverview down to components, instead of individual connections for each component.

Adds constructor / super to loadable components for passing props on.