### PR TITLE
removed stage 2 from babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,8 +2,7 @@
   "presets": [
     "@babel/preset-react",
     "@babel/preset-flow",
-    ["@babel/preset-env", {"targets": {"node": "current"}}],
-    ["@babel/preset-stage-2", {"decoratorsLegacy": true}]
+    ["@babel/preset-env", {"targets": {"node": "current"}}]
   ],
   "plugins": [
     "syntax-dynamic-import"


### PR DESCRIPTION
It threw in error in Heroku build, and I believe I was no longer using decorators